### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This [Helm](https://github.com/kubernetes/helm) chart installs [wallabag](https:
 ### Add Helm repository
 
 ```bash
-helm repo add wallabag https://huats.github.io/wallabag-helm/ 
+helm repo add huats https://huats.github.io/wallabag-helm/ 
 ```
 
 ### Configure the chart


### PR DESCRIPTION
If the repo with the name Wallabag is added, wallabag must also be used with helm install. Alternatively, change wallabag to huats in repo add wallabag, so that the helm install commands in the Readme are also correct.