### PR TITLE
Fix configmap annotations

### DIFF
--- a/charts/wallabag/templates/configmap.yaml
+++ b/charts/wallabag/templates/configmap.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ $fullName }}
   labels:
     {{- include "wallabag.labels" . | nindent 4 }}
-  {{- with .Values.ingress.annotations }}
+  {{- with .Values.wallabag.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/wallabag/values.yaml
+++ b/charts/wallabag/values.yaml
@@ -96,6 +96,8 @@ wallabag:
       # port: ""
       # user: root
     populate: True
+  # Annotations to add to the config map
+  annotations: {}
   fosuser:
     confirmation: true
     registration: true


### PR DESCRIPTION
The configmap use the ingress annotation settings. This is wrong. This patch changes to other value parameters.